### PR TITLE
feat: 팔로우/팔로잉 기능 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/follow/controller/FollowController.java
+++ b/backend/src/main/java/org/example/backend/domain/follow/controller/FollowController.java
@@ -1,0 +1,49 @@
+package org.example.backend.domain.follow.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.follow.dto.*;
+import org.example.backend.domain.follow.service.FollowService;
+import org.example.backend.global.requestcontext.RequestContext;
+import org.example.backend.global.rsdata.RsData;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/follows")
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollowService followService;
+    private final RequestContext requestContext;
+
+    // 팔로우하기
+    @PostMapping("/{followeeId}")
+    public ResponseEntity<RsData<FollowResponseDto>> follow(@PathVariable Long followeeId) {
+        Long currentMemberId = requestContext.getCurrentMemberId();
+        RsData<FollowResponseDto> response = followService.follow(currentMemberId, followeeId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 언팔로우하기
+    @DeleteMapping("/{followeeId}")
+    public ResponseEntity<RsData<Void>> unfollow(@PathVariable Long followeeId) {
+        Long currentMemberId = requestContext.getCurrentMemberId();
+        RsData<Void> response = followService.unfollow(currentMemberId, followeeId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 팔로워 목록 조회
+    @GetMapping("/{memberId}/followers")
+    public ResponseEntity<RsData<FollowListResponseDto>> getFollowers(@PathVariable Long memberId) {
+        RsData<FollowListResponseDto> response = followService.getFollowers(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 팔로잉 목록 조회
+        @GetMapping("/{memberId}/followings")
+    public ResponseEntity<RsData<FollowListResponseDto>> getFollowings(@PathVariable Long memberId) {
+        RsData<FollowListResponseDto> response = followService.getFollowings(memberId);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/backend/src/main/java/org/example/backend/domain/follow/dto/FollowListResponseDto.java
+++ b/backend/src/main/java/org/example/backend/domain/follow/dto/FollowListResponseDto.java
@@ -1,0 +1,20 @@
+package org.example.backend.domain.follow.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class FollowListResponseDto {
+    private List<FollowResponseDto> follows;
+    private long totalCount;
+
+    @Builder
+    public FollowListResponseDto(List<FollowResponseDto> follows, long totalCount) {
+        this.follows = follows;
+        this.totalCount = totalCount;
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/follow/dto/FollowResponseDto.java
+++ b/backend/src/main/java/org/example/backend/domain/follow/dto/FollowResponseDto.java
@@ -1,0 +1,27 @@
+package org.example.backend.domain.follow.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FollowResponseDto {
+    private Long follower;
+    private String followerNickname;
+    private String followerProfileImage;
+    private Long followee;
+    private String followeeNickname;
+    private String followeeProfileImage;
+
+    @Builder
+    public FollowResponseDto(Long follower, String followerNickname, String followerProfileImage,
+                           Long followee, String followeeNickname, String followeeProfileImage) {
+        this.follower = follower;
+        this.followerNickname = followerNickname;
+        this.followerProfileImage = followerProfileImage;
+        this.followee = followee;
+        this.followeeNickname = followeeNickname;
+        this.followeeProfileImage = followeeProfileImage;
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/follow/dto/FollowStatsResponseDto.java
+++ b/backend/src/main/java/org/example/backend/domain/follow/dto/FollowStatsResponseDto.java
@@ -1,0 +1,18 @@
+package org.example.backend.domain.follow.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FollowStatsResponseDto {
+    private long followerCount; // 나를 팔로우하는 사람 수
+    private long followingCount; // 내가 팔로우하는 사람 수
+
+    @Builder
+    public FollowStatsResponseDto(long followerCount, long followingCount) {
+        this.followerCount = followerCount;
+        this.followingCount = followingCount;
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/follow/entity/Follow.java
+++ b/backend/src/main/java/org/example/backend/domain/follow/entity/Follow.java
@@ -1,0 +1,43 @@
+package org.example.backend.domain.follow.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "follow", 
+       uniqueConstraints = @UniqueConstraint(columnNames = {"follower", "followee"}))
+@IdClass(FollowId.class)
+public class Follow {
+
+    @Id
+    @Column(name = "follower")
+    private Long follower;
+    
+    @Id
+    @Column(name = "followee")
+    private Long followee;
+
+
+    @Builder
+    public Follow(Long follower, Long followee) {
+        this.follower = follower;
+        this.followee = followee;
+    }
+
+    // 자기 자신을 팔로우하는 것을 방지하는 로직
+    public void validateNotSelfFollow() {
+        if (this.follower.equals(this.followee)) {
+            throw new IllegalArgumentException("자기 자신을 팔로우할 수 없습니다.");
+        }
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/follow/entity/FollowId.java
+++ b/backend/src/main/java/org/example/backend/domain/follow/entity/FollowId.java
@@ -1,0 +1,16 @@
+package org.example.backend.domain.follow.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+// 팔로우 ID 클래스
+public class FollowId implements Serializable {
+    private Long follower;
+    private Long followee;
+}

--- a/backend/src/main/java/org/example/backend/domain/follow/repository/FollowRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,45 @@
+package org.example.backend.domain.follow.repository;
+
+import org.example.backend.domain.follow.entity.Follow;
+import org.example.backend.domain.follow.entity.FollowId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, FollowId> {
+
+    // 특정 사용자가 다른 사용자를 팔로우하고 있는지 확인
+    @Query("SELECT COUNT(f) > 0 FROM Follow f WHERE f.follower = :follower AND f.followee = :followee")
+    boolean existsByFollowerAndFollowee(@Param("follower") Long follower, @Param("followee") Long followee);
+    
+    // 특정 사용자를 팔로우하는 사람들 조회 (팔로워 목록)
+    @Query("SELECT f FROM Follow f WHERE f.followee = :followee")
+    List<Follow> findByFollowee(@Param("followee") Long followee);
+
+    // 특정 사용자가 팔로우하는 사람들 조회 (팔로잉 목록)
+    @Query("SELECT f FROM Follow f WHERE f.follower = :follower")
+    List<Follow> findByFollower(@Param("follower") Long follower);
+
+    // 팔로우 관계 삭제 (ID 기반)
+    @Modifying
+    @Query("DELETE FROM Follow f WHERE f.follower = :follower AND f.followee = :followee")
+    void deleteByFollowerAndFollowee(@Param("follower") Long follower, @Param("followee") Long followee);
+
+    // 특정 사용자의 팔로워 수 조회
+    @Query("SELECT COUNT(f) FROM Follow f WHERE f.followee = :followee")
+    long countByFollowee(@Param("followee") Long followee);
+
+    // 특정 사용자의 팔로잉 수 조회
+    @Query("SELECT COUNT(f) FROM Follow f WHERE f.follower = :follower")
+    long countByFollower(@Param("follower") Long follower);
+
+    // 팔로우 관계 조회 (ID 기반)
+    @Query("SELECT f FROM Follow f WHERE f.follower = :follower AND f.followee = :followee")
+    Optional<Follow> findByFollowerAndFollowee(@Param("follower") Long follower, @Param("followee") Long followee);
+}

--- a/backend/src/main/java/org/example/backend/domain/follow/service/FollowService.java
+++ b/backend/src/main/java/org/example/backend/domain/follow/service/FollowService.java
@@ -1,0 +1,198 @@
+package org.example.backend.domain.follow.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.follow.dto.*;
+import org.example.backend.domain.follow.entity.Follow;
+import org.example.backend.domain.follow.repository.FollowRepository;
+import org.example.backend.domain.member.entity.Member;
+import org.example.backend.domain.member.repository.MemberRepository;
+import org.example.backend.global.exception.ServiceException;
+import org.example.backend.global.rsdata.RsData;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FollowService {
+
+    private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
+
+    // 팔로우하기
+    public RsData<FollowResponseDto> follow(Long follower, Long followee) {
+
+        if (follower.equals(followee)) {
+            throw new ServiceException("400", "자기 자신을 팔로우할 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        Member followerMember = memberRepository.findById(follower)
+            .orElseThrow(
+                () -> new ServiceException("404", "팔로워를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        Member followeeMember = memberRepository.findById(followee)
+            .orElseThrow(
+                () -> new ServiceException("404", "팔로이를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        if (followRepository.existsByFollowerAndFollowee(follower, followee)) {
+            throw new ServiceException("400", "이미 팔로우하고 있습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        Follow followEntity = Follow.builder()
+            .follower(follower)
+            .followee(followee)
+            .build();
+
+        followEntity.validateNotSelfFollow();
+        followRepository.save(followEntity);
+
+        FollowResponseDto responseDto = FollowResponseDto.builder()
+            .follower(followerMember.getMemberId())
+            .followerNickname(followerMember.getNickname())
+            .followerProfileImage(followerMember.getProfileImage())
+            .followee(followeeMember.getMemberId())
+            .followeeNickname(followeeMember.getNickname())
+            .followeeProfileImage(followeeMember.getProfileImage())
+            .build();
+
+        return new RsData<>("200", "팔로우가 완료되었습니다.", responseDto);
+    }
+
+    public RsData<Void> unfollow(Long follower, Long followee) {
+
+        if (!memberRepository.existsById(follower)) {
+            throw new ServiceException("404", "팔로워를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+
+        if (!memberRepository.existsById(followee)) {
+            throw new ServiceException("404", "팔로이를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+
+        if (!followRepository.existsByFollowerAndFollowee(follower, followee)) {
+            throw new ServiceException("400", "팔로우 관계가 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        followRepository.deleteByFollowerAndFollowee(follower, followee);
+        return new RsData<>("200", "언팔로우가 완료되었습니다.", null);
+    }
+
+
+    @Transactional(readOnly = true)
+    public RsData<FollowListResponseDto> getFollowers(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new ServiceException("404", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        List<Follow> follows = followRepository.findByFollowee(memberId);
+        long totalCount = followRepository.countByFollowee(memberId);
+
+        // 팔로워들의 ID 수집
+        List<Long> followerIds = follows.stream()
+            .map(Follow::getFollower)
+            .collect(Collectors.toList());
+
+        // 팔로워들의 정보 조회
+        Map<Long, Member> followerMap = memberRepository.findAllById(followerIds)
+            .stream()
+            .collect(Collectors.toMap(Member::getMemberId, follower -> follower));
+
+        List<FollowResponseDto> followDtos = follows.stream()
+            .map(follow -> {
+                Member follower = followerMap.get(follow.getFollower());
+                return FollowResponseDto.builder()
+                    .follower(follow.getFollower())
+                    .followerNickname(follower.getNickname())
+                    .followerProfileImage(follower.getProfileImage())
+                    .followee(follow.getFollowee())
+                    .followeeNickname(member.getNickname())
+                    .followeeProfileImage(member.getProfileImage())
+                    .build();
+            })
+            .collect(Collectors.toList());
+
+        FollowListResponseDto responseDto = FollowListResponseDto.builder()
+            .follows(followDtos)
+            .totalCount(totalCount)
+            .build();
+
+        return new RsData<>("200", "팔로워 목록을 조회했습니다.", responseDto);
+    }
+
+    // 팔로잉 목록 조회
+    @Transactional(readOnly = true)
+    public RsData<FollowListResponseDto> getFollowings(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new ServiceException("404", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        List<Follow> follows = followRepository.findByFollower(memberId);
+        long totalCount = followRepository.countByFollower(memberId);
+
+        // 팔로이들의 ID 수집
+        List<Long> followeeIds = follows.stream()
+            .map(Follow::getFollowee)
+            .collect(Collectors.toList());
+
+        // 팔로이들의 정보 조회
+        Map<Long, Member> followeeMap = memberRepository.findAllById(followeeIds)
+            .stream()
+            .collect(Collectors.toMap(Member::getMemberId, followee -> followee));
+
+        List<FollowResponseDto> followDtos = follows.stream()
+            .map(follow -> {
+                Member followee = followeeMap.get(follow.getFollowee());
+                return FollowResponseDto.builder()
+                    .follower(follow.getFollower())
+                    .followerNickname(member.getNickname())
+                    .followerProfileImage(member.getProfileImage())
+                    .followee(follow.getFollowee())
+                    .followeeNickname(followee.getNickname())
+                    .followeeProfileImage(followee.getProfileImage())
+                    .build();
+            })
+            .collect(Collectors.toList());
+
+        FollowListResponseDto responseDto = FollowListResponseDto.builder()
+            .follows(followDtos)
+            .totalCount(totalCount)
+            .build();
+
+        return new RsData<>("200", "팔로잉 목록을 조회했습니다.", responseDto);
+    }
+
+    // 팔로워 수 조회
+    @Transactional(readOnly = true)
+    public long getFollowerCount(Long memberId) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new ServiceException("404", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+        return followRepository.countByFollowee(memberId);
+    }
+
+    // 팔로잉 수 조회
+    @Transactional(readOnly = true)
+    public long getFollowingCount(Long memberId) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new ServiceException("404", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+        return followRepository.countByFollower(memberId);
+    }
+
+    // 팔로잉 여부 확인(추후에 게시글 조회 시 사용)
+    @Transactional(readOnly = true)
+    public boolean isFollowing(Long followerId, Long followeeId) {
+        if (followerId == null || followeeId == null) {
+            return false;
+        }
+        if (followerId.equals(followeeId)) {
+            return false; // 자기 자신은 팔로잉하지 않은 것으로 처리
+        }
+        return followRepository.existsByFollowerAndFollowee(followerId, followeeId);
+    }
+
+}


### PR DESCRIPTION
## 📎 Issue 번호<!-- 이슈 번호를 적어주세요 -->
closed #43 

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
feat: 팔로우/팔로잉 기능 구현

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 팔로우기능
  - 팔로우 시 이미 팔로우 되어있는 경우 팔로우 불가
  - 자신 팔로우 불가
- 언팔로우 기능 
- 팔로우 목록
- 팔로잉 목록
- 팔로우/팔로잉 숫자
- 팔로우 여부

참고자료 : [인스타그램 팔로우 관계는 어떻게 관리될까?-velog](https://velog.io/@evelyn82ny/instagram-follow#%EC%83%9D%EA%B0%81-1)
## ✅ 체크리스트 <!-- 체크 리스트를 작성해서 본인이 확인해보고 추가로 팀원이 리뷰할 때 확인 했으면 하는 부분 작성해주세요 -->

- [x] 예외 처리 충분히 고려함
- [x] 코드 오류가 없음
- [x] 이슈 연결
- [ ] 엔티티를 복합키로 만듬 followid를 만들어서 복합키로 설정
- [ ] 복합키로 만들기 위해서 현재 팔로우 엔티티는 멤버 엔티티를 참조를 안함 그래서 팔로우 목록 조회 시 사용자의 수를 조회하고 팔로우 목록을 조회하는 jpa n+1조회 문제가 발생하기 때문에 리포지터리에 `@Query`문을 따로 작성하여 n+1문제 해결
