### PR TITLE
feat : 팔로우 기능 구현

### DIFF
--- a/backend/src/main/java/org/example/backend/domain/follow/repository/FollowRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/follow/repository/FollowRepository.java
@@ -2,6 +2,7 @@ package org.example.backend.domain.follow.repository;
 
 import java.util.List;
 import org.example.backend.domain.follow.entity.Follow;
+import org.example.backend.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -30,4 +31,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     @Query("SELECT f FROM Follow f JOIN FETCH f.followee WHERE f.follower.memberId = :followerId")
     List<Follow> findFollowingsWithMemberInfo(@Param("followerId") Long followerId);
 
-}
+    boolean existsByFollowerAndFollowee(Member member, Member member2);
+
+    @Query("SELECT f.followee.memberId FROM Follow f WHERE f.follower = :member")
+    List<Long> findFolloweeIdsByFollower(@Param("member") Member member);}

--- a/backend/src/main/java/org/example/backend/domain/post/dto/PostReadResponseDto.java
+++ b/backend/src/main/java/org/example/backend/domain/post/dto/PostReadResponseDto.java
@@ -12,7 +12,9 @@ public record PostReadResponseDto(
     LocalDateTime createDate,
     List<String> images,
     int likeCount,
-    boolean liked
+    boolean liked,
+    boolean following,
+    Long authorId
 
 ) {
 

--- a/backend/src/main/java/org/example/backend/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/post/repository/PostRepository.java
@@ -3,6 +3,7 @@ package org.example.backend.domain.post.repository;
 import java.util.List;
 import org.example.backend.domain.post.entity.Post;
 import org.example.backend.domain.post.entity.Post.BoardType;
+import org.example.backend.domain.post.entity.Post.Displaying;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,4 +14,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByBoardType(BoardType boardType);
 
     long countByBoardTypeAndDisplaying(BoardType boardType, Post.Displaying displaying);
+
+    Page<Post> findByBoardTypeAndDisplayingAndAuthor_MemberIdIn(BoardType boardType, Displaying displaying, List<Long> followeeIds, Pageable pageable);
 }

--- a/backend/src/main/java/org/example/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/org/example/backend/domain/post/service/PostService.java
@@ -102,4 +102,8 @@ public class PostService {
     public int countByBoardTypeAndDisplaying(BoardType boardType, Displaying displaying) {
         return (int) postRepository.countByBoardTypeAndDisplaying(boardType, displaying);
     }
+
+    public Page<Post> findByBoardTypeAndDisplayingAndAuthorIdIn(BoardType boardType, Displaying displaying, List<Long> followeeIds, Pageable pageable) {
+        return postRepository.findByBoardTypeAndDisplayingAndAuthor_MemberIdIn(boardType, displaying, followeeIds, pageable);
+    }
 }


### PR DESCRIPTION
팔로잉 활성화
<img width="656" height="768" alt="스크린샷 2025-10-21 122529" src="https://github.com/user-attachments/assets/3bbb8391-6a4d-45b9-9be4-08af1ce604f4" />

팔로우 버튼 생성
<img width="641" height="767" alt="스크린샷 2025-10-21 122536" src="https://github.com/user-attachments/assets/b1934732-69a7-40d9-905a-1ebafb5f6e16" />

상세 페이지에도 팔로잉 버튼 생성
<img width="759" height="277" alt="스크린샷 2025-10-21 122542" src="https://github.com/user-attachments/assets/41456cc4-d38d-48bb-9f8b-24ef62b85b60" />

## 📎 Issue 번호<!-- 이슈 번호를 적어주세요 -->
<!-- closed #101 -->
closed #101

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 게시판에 팔로잉 기능 도입
- 팔로우한 사용자 게시글만 보기 구현

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 자랑 게시판 목록에서 팔로우 가능(팔로우 시 다른 게시글도 팔로우 상태 업데이트)
- 자랑게시판 상세 페이지에서도 팔로우 가능 및 상태 확인 가능
- 자랑 게시판 목록에서 상단의 팔로잉 클릭으로 활성화 시 팔로우 한 사용자 게시글 목록 확인

## ✅ 체크리스트 <!-- 체크 리스트를 작성해서 본인이 확인해보고 추가로 팀원이 리뷰할 때 확인 했으면 하는 부분 작성해주세요 -->

- [ ] 예외 처리 충분히 고려함
- [x] 코드 오류가 없음
- [x] 이슈 연결
