### PR TITLE
fix: AquariumLog, FishLog 응답코드 리팩토링에 따라 프론트엔드 코드 수정

### DIFF
--- a/frontend/src/app/aquarium/[id]/page.tsx
+++ b/frontend/src/app/aquarium/[id]/page.tsx
@@ -276,7 +276,7 @@ export default function AquariumDetailPage() {
     })
       .then(res => res.json())
       .then(json => {
-        setFishStatuses(prev => [json, ...prev]);
+        setFishStatuses(prev => [json.data, ...prev]);
         setNewFishStatus('');
         setNewFishStatusDate('');
         setAddingStatusFishId(null);
@@ -409,7 +409,7 @@ export default function AquariumDetailPage() {
       .then(res => res.json())
       .then(json => {
         setEnvironmentData(prev => {
-          const updated = [json, ...prev];
+          const updated = [json.data, ...prev];
           return updated.sort((a, b) => new Date(b.logDate).getTime() - new Date(a.logDate).getTime());
         });
         setNewTemperature('');


### PR DESCRIPTION
## 📎 Issue 번호<!-- 이슈 번호를 적어주세요 -->
<!-- closed #번호 -->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
**어항 개별 페이지** 프론트엔드 코드 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
AquariumLog, FishLog의 응답코드를 리팩토링하면서(`ResponseEntity` ➡️ `ApiResponse`),
이전 응답코드와 리팩토링 응답코드 구조가 바뀌어, 프론트엔드에서 어항, 물고기상태 데이터를 제대로 가져오지 못하는 문제 발생
➡️ `ApiResponse` 구조에 맞게 프론트엔드 코드 수정

## ✅ 체크리스트 <!-- 체크 리스트를 작성해서 본인이 확인해보고 추가로 팀원이 리뷰할 때 확인 했으면 하는 부분 작성해주세요 -->

- [ ] 예외 처리 충분히 고려함
- [x] 코드 오류가 없음
- [ ] 이슈 연결